### PR TITLE
ログイン後にアクティブな試合を表示

### DIFF
--- a/src/main/java/oit/is/z2635/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z2635/kaizi/janken/controller/JankenController.java
@@ -40,6 +40,9 @@ public class JankenController {
     model.addAttribute("users", user);
     ArrayList<Match> match = MatchMapper.selectAllByMatch();
     model.addAttribute("matchs", match);
+
+    ArrayList<MatchInfo> matchsInfo = MatchInfoMapper.selectAllByIsActive();
+    model.addAttribute("matchsInfo", matchsInfo);
     return "janken.html";
   }
 

--- a/src/main/java/oit/is/z2635/kaizi/janken/model/MatchInfoMapper.java
+++ b/src/main/java/oit/is/z2635/kaizi/janken/model/MatchInfoMapper.java
@@ -12,6 +12,9 @@ public interface MatchInfoMapper {
   @Select("SELECT * from matchinfo")
   ArrayList<Match> selectAllByMatchInfo();
 
+  @Select("SELECT * from matchinfo where true = isActive")
+  ArrayList<MatchInfo> selectAllByIsActive();
+
   @Insert("INSERT INTO MatchInfo (user1, user2, user1Hand, isActive) VALUES (#{user1},#{user2},#{user1Hand},#{isActive});")
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
   void insertMatchInfo(MatchInfo MatchInfo);

--- a/src/main/resources/templates/janken.html
+++ b/src/main/resources/templates/janken.html
@@ -22,6 +22,18 @@
     </li>
   </ul>
 
+  <h1>アクティブな試合</h1>
+
+  <p th:if="${matchsInfo}">
+  <div th:each="matchInfo,stat:${matchsInfo}">
+    <tr>
+      <td>id:[[${matchInfo.id}]]</td>
+      <td>user1:[[${matchInfo.user1}]]</td>
+      <td>user2:[[${matchInfo.user2}]]</td>
+      <td>isActive:[[${matchInfo.isActive}]]</td>
+    </tr>
+  </div>
+
   <h1>試合結果</h1>
 
   <p th:if="${matchs}">


### PR DESCRIPTION
「いがき」でログインし，jankenのページのエントリーから「ほんだ」を選び，
matchのページで手を選び，waitのページに遷移するようにした。
また、シークレットモードで「ほんだ」でログインし，
jankenのページでアクティブな試合について
「id:(MatchInfoのidが表示される) user1:(MatchInfoのuser1が表示される) user2:(MatchInfoのuser1が表示される) isActive:(MatchInfoのisActiveが表示される)」の様に表示されるようにした。
MatchInfoMapper.java、JankenController.java、janken.htmlを編集した。